### PR TITLE
Upgrade ZooKeeper version and add support for r6i instance type

### DIFF
--- a/templates/clickhouse-arm-entrypoint-existing-vpc.template.yaml
+++ b/templates/clickhouse-arm-entrypoint-existing-vpc.template.yaml
@@ -273,11 +273,10 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.5.10'
-    - '3.6.3'
     - '3.7.1'
-    Default: '3.5.10'
-    Description: Zookeeper version (3.5.10).
+    - '3.8.2'
+    Default: '3.8.2'
+    Description: Zookeeper version (3.8.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3

--- a/templates/clickhouse-arm-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-arm-entrypoint-new-vpc.template.yaml
@@ -289,11 +289,10 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.5.10'
-    - '3.6.3'
     - '3.7.1'
-    Default: '3.5.10'
-    Description: Zookeeper version (3.5.10).
+    - '3.8.2'
+    Default: '3.8.2'
+    Description: Zookeeper version (3.8.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3

--- a/templates/clickhouse-entrypoint-existing-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-existing-vpc.template.yaml
@@ -272,11 +272,10 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.5.10'
-    - '3.6.3'
     - '3.7.1'
-    Default: '3.5.10'
-    Description: ZooKeeper version (3.5.10).
+    - '3.8.2'
+    Default: '3.8.2'
+    Description: ZooKeeper version (3.8.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3

--- a/templates/clickhouse-entrypoint-existing-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-existing-vpc.template.yaml
@@ -343,6 +343,11 @@ Parameters:
       - r5.2xlarge
       - r5.4xlarge
       - r5.8xlarge
+      - r6i.large
+      - r6i.xlarge
+      - r6i.2xlarge
+      - r6i.4xlarge
+      - r6i.8xlarge
       - i3.large
       - i3.xlarge
       - i3.2xlarge

--- a/templates/clickhouse-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-new-vpc.template.yaml
@@ -287,11 +287,10 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.5.10'
-    - '3.6.3'
     - '3.7.1'
-    Default: '3.5.10'
-    Description: ZooKeeper version (3.5.10).
+    - '3.8.2'
+    Default: '3.8.2'
+    Description: ZooKeeper version (3.8.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3

--- a/templates/clickhouse-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-new-vpc.template.yaml
@@ -358,6 +358,11 @@ Parameters:
       - r5.2xlarge
       - r5.4xlarge
       - r5.8xlarge
+      - r6i.large
+      - r6i.xlarge
+      - r6i.2xlarge
+      - r6i.4xlarge
+      - r6i.8xlarge
       - i3.large
       - i3.xlarge
       - i3.2xlarge

--- a/templates/clickhouse.template.yaml
+++ b/templates/clickhouse.template.yaml
@@ -219,6 +219,11 @@ Parameters:
       - r5.2xlarge
       - r5.4xlarge
       - r5.8xlarge
+      - r6i.large
+      - r6i.xlarge
+      - r6i.2xlarge
+      - r6i.4xlarge
+      - r6i.8xlarge
       - i3.large
       - i3.xlarge
       - i3.2xlarge

--- a/templates/zookeeper.template.yaml
+++ b/templates/zookeeper.template.yaml
@@ -139,11 +139,10 @@ Parameters:
       - i3.16xlarge
   ZookeeperVersion:
     AllowedValues:
-    - '3.5.10'
-    - '3.6.3'
     - '3.7.1'
-    Default: '3.5.10'
-    Description: ZooKeeper version (3.5.10).
+    - '3.8.2'
+    Default: '3.8.2'
+    Description: ZooKeeper version (3.8.2).
     Type: String
   ZookeeperNodeCount:
     Default: 3


### PR DESCRIPTION
* ZooKeeper version 3.5.10 and 3.6.3 are end of life. We need to remove them and add support for the latest stable version  3.8.2.
* Add support for r6i instance type on x86.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
