### PR TITLE
 Add support for ClickHouse 23.3.8.21 on x86

### DIFF
--- a/scripts/clickhouse-client-install.sh
+++ b/scripts/clickhouse-client-install.sh
@@ -24,9 +24,15 @@ sleep 1
 
 
 yum install yum-utils
-rpm --import https://repo.clickhouse.tech/CLICKHOUSE-KEY.GPG
-yum-config-manager --add-repo https://repo.clickhouse.tech/rpm/stable/x86_64
-yum install clickhouse-client-$1 -y
+
+if [ $1 = 23.3.8.21 ]; then
+  sudo yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
+  sudo yum install clickhouse-client-$1 -y
+else
+  rpm --import https://repo.clickhouse.tech/CLICKHOUSE-KEY.GPG
+  sudo yum-config-manager --add-repo https://repo.clickhouse.tech/rpm/stable/x86_64
+  sudo yum install clickhouse-client-$1 -y
+fi
 sleep 1
 if [ ! -d "/etc/clickhouse-client" ]; then
     echo "Try to download from https://mirrors.tuna.tsinghua.edu.cn/clickhouse/"

--- a/templates/clickhouse-entrypoint-existing-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-existing-vpc.template.yaml
@@ -50,6 +50,7 @@ Metadata:
       - ClickHouseVolumeType
       - ClickHouseVolumeSize
       - ClickHouseIops
+      - ClickHousePkgS3URI
       - Architecture
       - DistributedProductMode
       - LoadBalancing
@@ -129,6 +130,8 @@ Metadata:
         default: Volume size of ClickHouse nodes
       ClickHouseIops:
         default: IOPS of ClickHouse nodes
+      ClickHousePkgS3URI:
+        default: S3 uri for the bucket that has ClickHouse tgz files, e.g., s3://{YOUR_BUCKET}
       Architecture:
         default: Supported CPU architectures
       DistributedProductMode:
@@ -361,9 +364,14 @@ Parameters:
     # Default: '21.4.5.46-2'
     - '21.4.7.3-2'
     - '21.5.9.4-2'
-    Default: '21.5.9.4-2'
-    Description: ClickHouse version (21.4.5 or 21.5.5).
+    - '23.3.8.21'
+    Default: '23.3.8.21'
+    Description: ClickHouse version (21.4.7, 21.5.9 or 23.3.8.21).
     Type: String
+  ClickHousePkgS3URI:
+    Description:  S3 uri for the bucket that has ClickHouse tgz files, e.g., s3://{YOUR_BUCKET}
+    Type: String
+    Default: none
   ClickHouseTimezone:
     Default: Asia/Shanghai #America/Los_Angeles
     Description: ClickHouse time zone.
@@ -694,6 +702,7 @@ Resources:
         ClickHouseTimezone: !Ref ClickHouseTimezone
         ClickHouseNodeCount: !Ref ClickHouseNodeCount
         ClickHouseBucketName: !Ref ClickHouseBucket
+        ClickHousePkgS3URI: !Ref ClickHousePkgS3URI
         DeviceName: !Ref ClickHouseDeviceName
         VolumeType: !Ref ClickHouseVolumeType
         VolumeSize: !Ref ClickHouseVolumeSize

--- a/templates/clickhouse-entrypoint-new-vpc.template.yaml
+++ b/templates/clickhouse-entrypoint-new-vpc.template.yaml
@@ -50,6 +50,7 @@ Metadata:
       - ClickHouseVolumeType
       - ClickHouseVolumeSize
       - ClickHouseIops
+      - ClickHousePkgS3URI
       - Architecture
       - DistributedProductMode
       - LoadBalancing
@@ -129,6 +130,8 @@ Metadata:
         default: Volume size of ClickHouse nodes
       ClickHouseIops:
         default: IOPS of ClickHouse nodes
+      ClickHousePkgS3URI:
+        default: S3 uri for the bucket that has ClickHouse tgz files, e.g., s3://{YOUR_BUCKET}
       Architecture:
         default: Supported CPU architectures
       DistributedProductMode:
@@ -376,9 +379,14 @@ Parameters:
     # Default: '21.4.5.46-2'
     - '21.4.7.3-2'
     - '21.5.9.4-2'
-    Default: '21.5.9.4-2'
-    Description: ClickHouse version (21.4.5 or 21.5.5).
+    - '23.3.8.21'
+    Default: '23.3.8.21'
+    Description: ClickHouse version (21.4.7, 21.5.9 or 23.3.8.21).
     Type: String
+  ClickHousePkgS3URI:
+    Description: S3 uri for the bucket that has ClickHouse tgz files, e.g., s3://{YOUR_BUCKET}
+    Type: String
+    Default: none
   ClickHouseTimezone:
     Default: 'Asia/Shanghai' #America/Los_Angeles
     Description: ClickHouse time zone.
@@ -766,6 +774,7 @@ Resources:
         ClickHouseTimezone: !Ref ClickHouseTimezone
         ClickHouseNodeCount: !Ref ClickHouseNodeCount
         ClickHouseBucketName: !Ref ClickHouseBucket
+        ClickHousePkgS3URI: !Ref ClickHousePkgS3URI
         DeviceName: !Ref ClickHouseDeviceName
         VolumeType: !Ref ClickHouseVolumeType
         VolumeSize: !Ref ClickHouseVolumeSize

--- a/templates/clickhouse.template.yaml
+++ b/templates/clickhouse.template.yaml
@@ -32,6 +32,7 @@ Metadata:
       - ClickHouseNodeCount
       - SecretId
       - ClickHouseBucketName
+      - ClickHousePkgS3URI
       - MoveFactor
       - RootStackName
       - DeviceName
@@ -97,6 +98,8 @@ Metadata:
         default: Number of ClickHouse nodes
       ClickHouseBucketName:
         default: ClickHouse bucket name
+      ClickHousePkgS3URI:
+        default: S3 uri for the bucket that has ClickHouse tgz files, e.g., s3://{YOUR_BUCKET}
       MoveFactor:
         default: Move factor
       RootStackName:
@@ -237,8 +240,9 @@ Parameters:
     # Default: '21.4.5.46-2'
     - '21.4.7.3-2'
     - '21.5.9.4-2'
-    Default: '21.5.9.4-2'
-    Description: ClickHouse version (21.4.5 or 21.5.5).
+    - '23.3.8.21'
+    Default: '23.3.8.21'
+    Description: ClickHouse version (21.4.7, 21.5.9 or 23.3.8.21).
     Type: String
   ClickHouseTimezone:
     Default: Asia/Shanghai
@@ -252,6 +256,10 @@ Parameters:
     Default: clickhouse-data
     Description: ClickHouse bucket name.
     Type: String
+  ClickHousePkgS3URI:
+    Description: S3 uri for the bucket that has ClickHouse tgz files, e.g., s3://{YOUR_BUCKET}
+    Type: String
+    Default: none
   MoveFactor:
     Default: 0.3
     Description: Tiered storage parameter.
@@ -409,7 +417,6 @@ Resources:
   ClickHouseMainLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "ClickHouseLogGroup"
       RetentionInDays: 180
   ClickHouseInstanceRole:
     Type: AWS::IAM::Role
@@ -465,7 +472,7 @@ Resources:
               - s3:GetIntelligentTieringConfiguration
               - s3:PutIntelligentTieringConfiguration
               - s3:PutLifecycleConfiguration
-            Resource: !Sub arn:${InstanceRoleArn}:s3:::*/*
+            Resource: !Sub arn:${InstanceRoleArn}:s3:::*
           - Effect: Allow
             Action:
               - ec2:CreateTags
@@ -987,7 +994,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}
             
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize} "01" "01" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "01" "01" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600
@@ -1251,7 +1258,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/clickhouse-install.sh ./ --region ${AWS::Region}
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "01" "02" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "01" "02" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600
@@ -1515,7 +1522,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/clickhouse-install.sh ./ --region ${AWS::Region}
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "02" "01" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "02" "01" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600
@@ -1779,7 +1786,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/clickhouse-install.sh ./ --region ${AWS::Region}
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "02" "02" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "02" "02" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600
@@ -2044,7 +2051,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/clickhouse-install.sh ./ --region ${AWS::Region} 
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}   
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "03" "01" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "03" "01" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600
@@ -2309,7 +2316,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/clickhouse-install.sh ./ --region ${AWS::Region}
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "03" "02" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "03" "02" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600
@@ -2574,7 +2581,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/clickhouse-install.sh ./ --region ${AWS::Region}
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "04" "01" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "04" "01" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600
@@ -2839,7 +2846,7 @@ Resources:
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/clickhouse-install.sh ./ --region ${AWS::Region}
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/create-table-demo.sql ./ --region ${AWS::Region}
             chmod +x clickhouse-install.sh
-            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "04" "02" > ch-install.log
+            ./clickhouse-install.sh ${ClickHouseVersion} ${ClickHouseNodeCount} ${RootStackName} ${AWS::Region} http://s3.${AWS::Region}.${AWS::URLSuffix}/${ClickHouseBucketName}/quickstart-clickhouse-data/ ${MoveFactor} ${ClickHouseTimezone} ${ZookeeperPrivateIp1} ${ZookeeperPrivateIp2} ${ZookeeperPrivateIp3} `python ./find-secret.py secretfile ` ${MaxThreads} ${MaxInsertThreads} ${DistributedProductMode} ${MaxMemoryUsage} ${LoadBalancing} ${MaxDataPartSize}  "04" "02" ${ClickHousePkgS3URI} > ch-install.log
 
             chmod +r /home/ec2-user/create-table-demo.sql
             flag=600


### PR DESCRIPTION
*Issue #, if available:*
#62 

*Description of changes:*

Add support for ClickHouse 23.3.8.21 on x86.

One issue was that it takes too long to download ClickHouse installation packages in China region. And I was not able to find a  mirror for the yum repo for version 23.3.8.21. So we decided to add a `ClickHousePkgS3URI ` parameter to let customer upload ClickHouse tgz files manually to a S3 bucket in China region.

Tested in both global regions and China regions and everything looks good to me.