### PR TITLE
Fix rpm repo url for Clickhouse 21.4.7.3 and 21.5.9.4

### DIFF
--- a/scripts/clickhouse-client-install.sh
+++ b/scripts/clickhouse-client-install.sh
@@ -25,14 +25,9 @@ sleep 1
 
 yum install yum-utils
 
-if [ $1 = 23.3.8.21 ]; then
-  sudo yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
-  sudo yum install clickhouse-client-$1 -y
-else
-  rpm --import https://repo.clickhouse.tech/CLICKHOUSE-KEY.GPG
-  sudo yum-config-manager --add-repo https://repo.clickhouse.tech/rpm/stable/x86_64
-  sudo yum install clickhouse-client-$1 -y
-fi
+sudo yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
+sudo yum install clickhouse-client-$1 -y
+
 sleep 1
 if [ ! -d "/etc/clickhouse-client" ]; then
     echo "Try to download from https://mirrors.tuna.tsinghua.edu.cn/clickhouse/"

--- a/scripts/clickhouse-install.sh
+++ b/scripts/clickhouse-install.sh
@@ -40,31 +40,25 @@ ln -s /home/clickhouse/data/log/ /var/log/clickhouse-server
 
 yum install yum-utils
 
-if [ $1 = 23.3.8.21 ]; then
-  if [ "${20}" != "none" ]; then
-    sudo aws s3 sync ${20} ./ --region $4
-    find clickhouse*.tgz -exec tar -xzvf {} \;
+if [ $1 = 23.3.8.21 ] && [ "${20}" != "none" ]; then
+  sudo aws s3 sync ${20} ./ --region $4
+  find clickhouse*.tgz -exec tar -xzvf {} \;
 
-    sudo clickhouse-common-static-$1/install/doinst.sh
-    pw=""
-    sudo yum install expect -y
-    expect -f - <<-EOF
-      set timeout 10
-      spawn sudo "clickhouse-server-$1/install/doinst.sh"
-      expect "*?assword*"
-      send -- "$pw\r"
-      expect eof
+  sudo clickhouse-common-static-$1/install/doinst.sh
+  pw=""
+  sudo yum install expect -y
+  expect -f - <<-EOF
+    set timeout 10
+    spawn sudo "clickhouse-server-$1/install/doinst.sh"
+    expect "*?assword*"
+    send -- "$pw\r"
+    expect eof
 EOF
-    sudo "clickhouse-client-$1/install/doinst.sh"
-  else
-    sudo yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
-    sudo yum install clickhouse-server-$1 clickhouse-client-$1 -y
-  fi
-else
-  rpm --import https://repo.clickhouse.tech/CLICKHOUSE-KEY.GPG
-  yum-config-manager --add-repo https://repo.clickhouse.tech/rpm/stable/x86_64
-  yum install clickhouse-server-$1 clickhouse-client-$1 -y
+  sudo "clickhouse-client-$1/install/doinst.sh"
 fi
+
+sudo yum-config-manager --add-repo https://packages.clickhouse.com/rpm/clickhouse.repo
+sudo yum install clickhouse-server-$1 clickhouse-client-$1 -y
 
 if [ ! -d "/etc/clickhouse-server" ]; then
     rpm --import https://mirrors.aliyun.com/clickhouse/CLICKHOUSE-KEY.GPG


### PR DESCRIPTION
*Description of changes:*
Update repo url for ClickHouse 21.4.7.3 and 21.5.9.4 to use the same url as version 23.3.8.21.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
